### PR TITLE
Enable models to fully train on dataset without withheld Validation dataset 

### DIFF
--- a/opal/__main__.py
+++ b/opal/__main__.py
@@ -121,8 +121,9 @@ def entrypoint():
         "--p_test",
         "-p",
         type=float,
-        default=0.1,
-        help="Proportion of test data",
+        default=0,
+        help="Proportion of test data. Specify 0 to train on the entire "
+        "dataset",
     )
     args = parser.parse_args()
     dataset_path = Path.cwd() / args.dataset_path

--- a/opal/__main__.py
+++ b/opal/__main__.py
@@ -3,22 +3,10 @@ from __future__ import annotations
 import argparse
 from pathlib import Path
 
-import lightning as pl
-import torch
-from lightning.pytorch.callbacks import (
-    ModelCheckpoint,
-    EarlyStopping,
-    LearningRateMonitor,
-)
-
-from opal.data import OsuDataModule
-from opal.model.delta_model import DeltaModel
-from opal.utils import RSC_DIR
-
 
 def train(
     dataset_path: str | Path,
-    model_path: Path = RSC_DIR / "models",
+    model_path: Path,
     n_keys: int = 4,
     lr: float = 1e-3,
     batch_size: int = 2**10,
@@ -30,6 +18,19 @@ def train(
     l1_loss_weight: float = 0,
     l2_loss_weight: float = 0,
 ):
+    import lightning as pl
+    from lightning.pytorch.callbacks import (
+        ModelCheckpoint,
+        EarlyStopping,
+        LearningRateMonitor,
+    )
+
+    from opal.data import OsuDataModule
+    from opal.model.delta_model import DeltaModel
+    import torch
+
+    torch.set_float32_matmul_precision("medium")
+
     dm = OsuDataModule(
         n_keys=n_keys,
         dataset_path=dataset_path,
@@ -142,5 +143,4 @@ def entrypoint():
 
 
 if __name__ == "__main__":
-    torch.set_float32_matmul_precision("medium")
     entrypoint()

--- a/opal/data.py
+++ b/opal/data.py
@@ -93,17 +93,24 @@ class OsuDataModule(LightningDataModule):
         df_pr_mid[:] = minmax_scale(df_pr_mid)
         self.dt_mid_w.fit(df_pr_mid["w"])
 
-        df_train, df_test = train_test_split(
-            self.df, test_size=self.p_test, random_state=42
-        )
+        if self.p_test:
+            df_train, df_test = train_test_split(
+                self.df, test_size=self.p_test, random_state=42
+            )
 
-        # Fit the transform only on the training data to avoid data leakage
-        df_train["accuracy"] = self.qt_acc.fit_transform(
-            df_train[["accuracy"]].values
-        )
-        df_test["accuracy"] = self.qt_acc.transform(
-            df_test[["accuracy"]].values
-        )
+            # Fit the transform only on the training data to avoid data leakage
+            df_train["accuracy"] = self.qt_acc.fit_transform(
+                df_train[["accuracy"]].values
+            )
+            df_test["accuracy"] = self.qt_acc.transform(
+                df_test[["accuracy"]].values
+            )
+        else:
+            df_train = self.df[:]
+            df_test = self.df[0:0]
+            df_train["accuracy"] = self.qt_acc.fit_transform(
+                df_train[["accuracy"]].values
+            )
 
         self.ds_train = TensorDataset(
             tensor(df_train["uid"].to_numpy()),

--- a/opal/data.py
+++ b/opal/data.py
@@ -107,7 +107,7 @@ class OsuDataModule(LightningDataModule):
             )
         else:
             df_train = self.df[:]
-            df_test = self.df[0:0]
+            df_test = self.df[0 : self.batch_size]
             df_train["accuracy"] = self.qt_acc.fit_transform(
                 df_train[["accuracy"]].values
             )


### PR DESCRIPTION
See #5

This allows `p_test` to be 0, which then uses the entire dataset for training.
To enable compatibility to current systems, the validation is at least a batch size, to avoid issues with current monitoring metrics
